### PR TITLE
feat: recommended tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,48 @@ npm install --save-dev feathers-adapter-vitest
 
 ## Usage
 
+`defineTestSuite` returns a test suite function that you run against one or more
+services of your adapter:
+
 ```ts
 // index.test.ts
 
 import { defineTestSuite } from "feathers-adapter-vitest";
 
-const testSuite = defineTestSuite([
-  ".events",
-  // ... and so on
-]);
+const testSuite = defineTestSuite({
+  // skip individual tests your adapter does not support
+  skip: [".events"],
+  // ...or run only specific tests
+  // only: [".find", ".get"],
+});
+
+testSuite({ app, serviceName: "people" });
+testSuite({ app, serviceName: "people-customid", idProp: "customid" });
+```
+
+### Recommended operators
+
+Besides the standard syntax, some operators are common but **not** part of the
+absolute standard — only some adapters support them. Their tests are **opt-in**
+per operator and skipped by default:
+
+```ts
+const testSuite = defineTestSuite({
+  recommended: ["$not", "$regex"],
+});
+```
+
+Only enable an operator if your adapter supports it. Note that some adapters (e.g.
+those built on `@feathersjs/adapter-commons`) reject unknown query syntax unless it
+is whitelisted. Property-level operators (`$regex`, `$options`) go in the `operators`
+list, while `$not` is a **top-level** filter that negates a whole condition
+(`{ $not: { age: 20 } }`), so it also needs a `filters` entry:
+
+```ts
+new MyService({
+  operators: ["$regex", "$options", "$not"],
+  filters: { $not: (value) => value },
+});
 ```
 
 ## License

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -1,1 +1,7 @@
-export type Test = (name: string, runner: any) => void
+export type RecommendedOperator = '$not' | '$regex'
+
+export type Test = (
+  name: string,
+  runner: any,
+  options?: { recommended?: RecommendedOperator },
+) => void

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type { AdapterTestNameMethods } from './methods.js'
 import methodTests from './methods.js'
 import type { AdapterTestNameSyntax } from './syntax.js'
 import syntaxTests from './syntax.js'
+import type { RecommendedOperator } from './declarations.js'
 import { describe, it, beforeAll, assert } from 'vitest'
 
 export type TestSuiteOptions = {
@@ -30,13 +31,25 @@ export type DefineTestSuiteOptions = {
   blacklist?: AdapterTestName[]
   skip?: AdapterTestName[]
   only?: AdapterTestName[]
+  /**
+   * Opt in to recommended (non-standard) operator tests per operator.
+   * These tests are skipped by default. The adapter under test must support
+   * the operator (and, if applicable, whitelist it via its `operators` option).
+   *
+   * @example ['$not', '$regex']
+   */
+  recommended?: RecommendedOperator[]
 }
 
 export const defineTestSuite = (defineOptions?: DefineTestSuiteOptions) => {
   return (options: TestSuiteOptions) => {
     const { app, serviceName, idProp = 'id' } = options
 
-    const test = (name: string, runner: any) => {
+    const test = (
+      name: string,
+      runner: any,
+      testOptions?: { recommended?: RecommendedOperator },
+    ) => {
       let skip = false
       const skipNames = defineOptions?.skip || defineOptions?.blacklist || []
       if (skipNames.includes(name as AdapterTestName)) {
@@ -45,6 +58,14 @@ export const defineTestSuite = (defineOptions?: DefineTestSuiteOptions) => {
       if (
         defineOptions?.only?.length &&
         !defineOptions.only.includes(name as AdapterTestName)
+      ) {
+        skip = true
+      }
+      // recommended operator tests are opt-in: skipped unless the operator is
+      // explicitly enabled via `recommended: ['$not', ...]`
+      if (
+        testOptions?.recommended &&
+        !defineOptions?.recommended?.includes(testOptions.recommended)
       ) {
         skip = true
       }

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert'
 import { describe, beforeEach, afterEach } from 'vitest'
 import type { Application } from '@feathersjs/feathers'
-import type { Test } from './declarations.js'
+import type { RecommendedOperator, Test } from './declarations.js'
+import { withOptions } from './utils.js'
 
 type SyntaxTestOptions = {
   app: Application
@@ -18,6 +19,7 @@ type SyntaxTests = {
     | '.find + $limit'
     | '.find + $limit 0'
     | '.find + $skip'
+    | '.find + $sort + $limit + $skip'
     | '.find + $select'
   operators:
     | '.find + $or'
@@ -42,6 +44,14 @@ type SyntaxTests = {
     | '.find + paginate + $limit + $skip'
     | '.find + paginate + $limit 0'
     | '.find + paginate + params'
+  recommended:
+    | '.find + $not'
+    | '.find + $not + nested'
+    | '.find + $not + multi-key'
+    | '.find + $not + operator'
+    | '.find + $not + $or'
+    | '.find + $regex'
+    | '.find + $regex + $options'
 }
 
 export type AdapterTestNameSyntax = SyntaxTests[keyof SyntaxTests]
@@ -57,22 +67,19 @@ export default (options: SyntaxTestOptions) => {
   const { test, app, serviceName, idProp } = options
 
   describe('Syntax', () => {
-    let bob: any
-    let alice: any
-    let doug: any
     let service: any
 
     beforeEach(async () => {
       service = app.service(serviceName)
-      bob = await app.service(serviceName).create({
+      await service.create({
         name: 'Bob',
         age: 25,
       })
-      doug = await app.service(serviceName).create({
+      await service.create({
         name: 'Doug',
         age: 32,
       })
-      alice = await app.service(serviceName).create({
+      await service.create({
         name: 'Alice',
         age: 19,
       })
@@ -178,6 +185,23 @@ export default (options: SyntaxTestOptions) => {
           assert.strictEqual(data.length, 2, 'correct data.length')
           assert.strictEqual(data[0].name, 'Bob', 'first user')
           assert.strictEqual(data[1].name, 'Doug', 'second user')
+        },
+        '.find + $sort + $limit + $skip': async () => {
+          const data = await service.find({
+            query: {
+              $sort: { name: 1 },
+              $skip: 1,
+              $limit: 1,
+            },
+          })
+
+          // sorted asc: Alice, Bob, Doug → skip 1 → Bob, Doug → limit 1 → Bob
+          assert.strictEqual(data.length, 1, 'correct data.length')
+          assert.strictEqual(
+            data[0].name,
+            'Bob',
+            'correct order: sort → skip → limit',
+          )
         },
         '.find + $select': async () => {
           const data = await service.find({
@@ -427,18 +451,123 @@ export default (options: SyntaxTestOptions) => {
       })
     }
 
-    describe('paginate', function () {
-      beforeEach(() => {
-        service.options.paginate = {
-          default: 1,
-          max: 2,
+    // Opt-in tests for common (but non-standard) operators, skipped by default
+    // and enabled per operator via `defineTestSuite({ recommended: [...] })`.
+    const recommendedConfig = {
+      // `$not` negates a whole condition at the top level (not a per-property
+      // inversion). Adapters that support it may need to register it as a top
+      // level filter (e.g. `filters: { $not: (v) => v }`) in addition to the
+      // `operators` list.
+      $not: {
+        '.find + $not': async () => {
+          const data = await service.find({
+            query: {
+              $not: { name: 'Bob' },
+              $sort: { name: 1 },
+            },
+          })
+
+          // NOT (name = 'Bob') → Alice, Doug
+          assert.strictEqual(data.length, 2, 'correct data.length')
+          assert.strictEqual(data[0].name, 'Alice', 'first item')
+          assert.strictEqual(data[1].name, 'Doug', 'second item')
+        },
+        '.find + $not + nested': async () => {
+          const data = await service.find({
+            query: {
+              $and: [{ $not: { name: 'Bob' } }],
+              $sort: { name: 1 },
+            },
+          })
+
+          // $not nested inside $and → Alice, Doug
+          assert.strictEqual(data.length, 2, 'correct data.length')
+          assert.strictEqual(data[0].name, 'Alice', 'first item')
+          assert.strictEqual(data[1].name, 'Doug', 'second item')
+        },
+        '.find + $not + multi-key': async () => {
+          // Carol shares Bob's age but has a different name
+          await service.create({ name: 'Carol', age: 25 })
+
+          const data = await service.find({
+            query: {
+              $not: { age: 25, name: 'Bob' },
+              $sort: { name: 1 },
+            },
+          })
+
+          // NOT (age = 25 AND name = 'Bob') removes only Bob; Carol (age 25 but
+          // name != 'Bob') is kept. A per-property inversion would wrongly drop it.
+          assert.strictEqual(data.length, 3, 'correct data.length')
+          assert.strictEqual(data[0].name, 'Alice', 'first item')
+          assert.strictEqual(data[1].name, 'Carol', 'second item')
+          assert.strictEqual(data[2].name, 'Doug', 'third item')
+        },
+        '.find + $not + operator': async () => {
+          const data = await service.find({
+            query: {
+              $not: { age: { $gt: 25 } },
+              $sort: { name: 1 },
+            },
+          })
+
+          // NOT (age > 25) → Alice (19), Bob (25); Doug (32) excluded
+          assert.strictEqual(data.length, 2, 'correct data.length')
+          assert.strictEqual(data[0].name, 'Alice', 'first item')
+          assert.strictEqual(data[1].name, 'Bob', 'second item')
+        },
+        '.find + $not + $or': async () => {
+          const data = await service.find({
+            query: {
+              $not: { $or: [{ name: 'Bob' }, { name: 'Alice' }] },
+              $sort: { name: 1 },
+            },
+          })
+
+          // De Morgan: NOT (name = 'Bob' OR name = 'Alice') → Doug
+          assert.strictEqual(data.length, 1, 'correct data.length')
+          assert.strictEqual(data[0].name, 'Doug', 'correct item')
+        },
+      },
+      $regex: {
+        '.find + $regex': async () => {
+          const data = await service.find({
+            query: {
+              name: { $regex: 'li' },
+            },
+          })
+
+          // only 'Alice' contains 'li'
+          assert.strictEqual(data.length, 1, 'correct data.length')
+          assert.strictEqual(data[0].name, 'Alice', 'correct name')
+        },
+        '.find + $regex + $options': async () => {
+          const data = await service.find({
+            query: {
+              name: { $regex: 'alice', $options: 'i' },
+            },
+          })
+
+          // case-insensitive → 'Alice'
+          assert.strictEqual(data.length, 1, 'correct data.length')
+          assert.strictEqual(data[0].name, 'Alice', 'correct name')
+        },
+      },
+    } satisfies Record<RecommendedOperator, Partial<TestConfig<'recommended'>>>
+
+    describe('recommended', () => {
+      for (const operator in recommendedConfig) {
+        for (const testName in (recommendedConfig as any)[operator]) {
+          test(
+            testName,
+            async () => (recommendedConfig as any)[operator][testName](),
+            { recommended: operator as RecommendedOperator },
+          )
         }
-      })
+      }
+    })
 
-      afterEach(() => {
-        service.options.paginate = {}
-      })
-
+    describe('paginate', function () {
       const paginateConfig: TestConfig<'paginate'> = {
         '.find + paginate': async () => {
           const page = await service.find({
@@ -502,7 +631,11 @@ export default (options: SyntaxTestOptions) => {
       }
 
       for (const testName in paginateConfig) {
-        test(testName, async () => (paginateConfig as any)[testName]())
+        test(testName, async () =>
+          withOptions(service, { paginate: { default: 1, max: 2 } }, () =>
+            (paginateConfig as any)[testName](),
+          ),
+        )
       }
     })
   })

--- a/test/feathers-memory.test.ts
+++ b/test/feathers-memory.test.ts
@@ -5,10 +5,8 @@ import { MemoryService } from '@feathersjs/memory'
 import { describe } from 'vitest'
 
 const testSuite = defineTestSuite({
-  skip: [
-    '.update + id + query', // need to be fixed upstream, see https://github.com/feathersjs/feathers/pull/3617
-    '.update + id + query id', // need to be fixed upstream, see https://github.com/feathersjs/feathers/pull/3617
-  ],
+  skip: [],
+  recommended: ['$not', '$regex'],
 })
 
 describe('@feathersjs/memory', () => {
@@ -36,6 +34,8 @@ describe('@feathersjs/memory', () => {
     'people',
     new MemoryService<Person>({
       events,
+      operators: ['$not', '$regex', '$options'],
+      filters: { $not: (value) => value },
     }),
   )
 
@@ -56,6 +56,8 @@ describe('@feathersjs/memory', () => {
     new MemoryService<Person>({
       id: 'customid',
       events,
+      operators: ['$not', '$regex', '$options'],
+      filters: { $not: (value) => value },
     }),
   )
 


### PR DESCRIPTION
This pull request introduces opt-in tests for recommended (non-standard) query operators, such as `$not` and `$regex`, to the Feathers adapter test suite. It updates the test suite API to allow adapters to explicitly enable these tests, adds comprehensive test cases for these operators, and demonstrates their usage in the `@feathersjs/memory` adapter tests. The changes also include some minor improvements and refactoring to the test setup.

**Recommended Operator Support and Testing**

* The `defineTestSuite` API now accepts a `recommended` option to opt-in to tests for non-standard operators like `$not` and `$regex`. These tests are skipped by default unless enabled, ensuring compatibility with adapters that do not support them. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R34-R52) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R64-R71) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R58)
* Comprehensive recommended operator tests are implemented in `src/syntax.ts` for `$not` (including nested, multi-key, operator, and `$or` cases) and `$regex` (with and without `$options`). These tests are only run when the adapter opts in via the new API.

**Test Suite and Utility Improvements**

* The `Test` type is updated to accept an options argument for recommended operators, and the test runner logic is adjusted accordingly. [[1]](diffhunk://#diff-8594d52b520acb029489d79ec559239bde3c883d6d6662bd978e692740d34986L1-R7) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R64-R71)
* The test data setup in `src/syntax.ts` is simplified by removing unnecessary variables and using consistent service creation logic.
* A new test case for the `.find + $sort + $limit + $skip` syntax is added to improve coverage of standard query combinations. [[1]](diffhunk://#diff-65807de78ba86d73c300035ba644595225c08491a6bb0bd8189fc4d610dbcbcbR22) [[2]](diffhunk://#diff-65807de78ba86d73c300035ba644595225c08491a6bb0bd8189fc4d610dbcbcbR189-R205)

**Adapter Example Updates**

* The `@feathersjs/memory` test suite is updated to opt in to `$not` and `$regex` tests and to configure the service with the necessary `operators` and `filters` to support these operators. [[1]](diffhunk://#diff-c5707ebfb902c882dceea541cd43bd775f822b25d2299aba13488fd97458cf13L8-R9) [[2]](diffhunk://#diff-c5707ebfb902c882dceea541cd43bd775f822b25d2299aba13488fd97458cf13R37-R38) [[3]](diffhunk://#diff-c5707ebfb902c882dceea541cd43bd775f822b25d2299aba13488fd97458cf13R59-R60)

These changes make it easier to verify adapter support for advanced query operators in a standardized way while maintaining compatibility with adapters that do not implement them.